### PR TITLE
Token support

### DIFF
--- a/ghrfs.go
+++ b/ghrfs.go
@@ -46,11 +46,13 @@ func New(optFns ...optFunc) (*ReleaseFileSystem, error) {
 
 // NewWithOptions takes an options set and return a new RFS
 func NewWithOptions(opts *Options) (*ReleaseFileSystem, error) {
-	c, err := github.NewClient()
+	c, err := github.NewClient(
+		github.WithToken(opts.Token),
+		github.WithHost(opts.Host),
+	)
 	if err != nil {
 		return nil, err
 	}
-	c.Options.Host = opts.Host
 
 	rfs := &ReleaseFileSystem{
 		Options: *opts,
@@ -237,8 +239,9 @@ func (rfs *ReleaseFileSystem) OpenCachedFile(name string) (fs.File, error) {
 }
 
 // getClientForURL returns a github client configured for the hostname
-// of a URL.
-func getClientForURL(urlString string) (*github.Client, error) {
+// of a URL. The token authenticates the request, which is required to
+// download assets from private releases.
+func getClientForURL(urlString, token string) (*github.Client, error) {
 	// The download URL from the assets is not on the same host as
 	// the API, so we need a new client
 	u, err := url.Parse(urlString)
@@ -248,6 +251,7 @@ func getClientForURL(urlString string) (*github.Client, error) {
 
 	// Request the file using a client with the asset URL
 	c, err := github.NewClient(
+		github.WithToken(token),
 		github.WithHost(u.Hostname()),
 	)
 	if err != nil {
@@ -271,7 +275,7 @@ func (rfs *ReleaseFileSystem) OpenRemoteFile(name string) (fs.File, error) {
 	}
 
 	// Assets are not downloaded from the API, we need a new client
-	c, err := getClientForURL(asset.URL)
+	c, err := getClientForURL(asset.URL, rfs.Options.Token)
 	if err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -22,6 +22,11 @@ type Options struct {
 	CacheMaxSize      int64
 	CacheExtensions   []string
 	Tag               string
+	// Token is an access token used to authenticate against the GitHub API
+	// and to download release assets. It is required to read from private
+	// releases. When empty, the underlying GitHub client falls back to the
+	// GITHUB_TOKEN environment variable.
+	Token string
 }
 
 // Default options
@@ -69,6 +74,17 @@ func FromURL(urlString string) optFunc {
 func WithHost(hostname string) optFunc {
 	return func(opts *Options) error {
 		opts.Host = hostname
+		return nil
+	}
+}
+
+// WithToken sets an explicit access token used to authenticate against the
+// GitHub API and to download release assets. It is required to read from
+// private releases. When left unset, the underlying GitHub client falls back
+// to the GITHUB_TOKEN environment variable.
+func WithToken(token string) optFunc {
+	return func(opts *Options) error {
+		opts.Token = token
 		return nil
 	}
 }

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright 2025 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package ghrfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithToken(t *testing.T) {
+	t.Parallel()
+	opts := Options{}
+	require.NoError(t, WithToken("s3cr3t")(&opts))
+	require.Equal(t, "s3cr3t", opts.Token)
+}
+
+// TestGetClientForURL ensures the client used to download release assets is
+// configured with the token (required for private releases) and points at the
+// asset host rather than the API host.
+func TestGetClientForURL(t *testing.T) {
+	t.Parallel()
+	c, err := getClientForURL(
+		"https://github.com/example/repo/releases/download/v1.0.0/asset.txt", "s3cr3t",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "s3cr3t", c.Options.Token)
+	require.Equal(t, "github.com", c.Options.Host)
+}


### PR DESCRIPTION
This pull request adds support for authenticating with a GitHub access token, enabling access to private releases and assets. The token can be set explicitly via options or falls back to the `GITHUB_TOKEN` environment variable if unset. The changes also ensure the correct token is used when downloading assets and add tests to verify this behavior.

**Authentication and options enhancements:**

* Added a `Token` field to the `Options` struct, allowing explicit configuration of a GitHub access token for authenticating API requests and downloading release assets.
* Introduced the `WithToken` option function to set the token in `Options`, including documentation for its usage.
* Updated the `NewWithOptions` and `getClientForURL` functions to pass the token when creating a GitHub client, ensuring authenticated requests for both API and asset downloads. [[1]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bL49-L53) [[2]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bL240-R244) [[3]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bR254) [[4]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bL274-R278)

**Testing:**

* Added `token_test.go` with tests for the `WithToken` option and for verifying that the token is correctly configured when creating a client for asset downloads.