### PR TITLE
Fix linter nits and SBOM gen

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -33,4 +33,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.7
+          version: v2.12

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,18 +36,17 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install bom
-        uses: kubernetes-sigs/release-actions/setup-bom@c130b4494862d330a1aa4de320076c666d0708da # v0.4.4
-
-      - name: Generate SBOM
-        shell: bash
-        run: |
-          bom generate --format=json -o /tmp/${{github.event.repository.owner}}-${{github.event.repository.name}}-${{ steps.tag.outputs.tag_name }}.spdx.json .
-
       - name: Publish Release
         uses: kubernetes-sigs/release-actions/publish-release@c130b4494862d330a1aa4de320076c666d0708da # v0.4.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          assets: "/tmp/${{github.event.repository.owner}}-${{github.event.repository.name}}-${{ steps.tag.outputs.tag_name }}.spdx.json"
           sbom: false
+
+      - name: Generate SBOM
+        id: sbom
+        uses: carabiner-dev/actions/unpack/sbom@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+        with:
+          push-to-release: ${{ steps.tag.outputs.tag_name }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan

--- a/ghrfs.go
+++ b/ghrfs.go
@@ -178,7 +178,7 @@ func (rfs *ReleaseFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
 // Open opens a file.
 func (rfs *ReleaseFileSystem) Open(name string) (fs.File, error) {
 	if name == "." {
-		assets := []fs.DirEntry{}
+		assets := make([]fs.DirEntry, 0, len(rfs.Release.Assets))
 		for _, f := range rfs.Release.Assets {
 			assets = append(assets, f)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/carabiner-dev/ghrfs
 
-go 1.25.8
+go 1.25.12
 
 require (
 	github.com/carabiner-dev/github v0.2.3


### PR DESCRIPTION
This pull request updates dependencies and improves workflow configurations for better tooling and performance. The main changes include updating Go and linter versions, switching to a new SBOM generation action in the release workflow, and making a minor code optimization.

**Dependency and Tooling Updates:**

* Updated the Go version in `go.mod` from `1.25.8` to `1.25.12` to ensure compatibility with recent features and security patches.
* Upgraded `golangci-lint` in `.github/workflows/golangci-lint.yaml` from version `v2.7` to `v2.12` for improved linting capabilities.
* Changed the linter configuration in `.golangci.yaml` to use `gomodguard_v2` instead of `gomodguard` for enhanced module guard checks.

**Release Workflow Improvements:**

* Replaced the previous SBOM generation steps in `.github/workflows/release.yaml` with the `carabiner-dev/actions/unpack/sbom` GitHub Action, streamlining SBOM generation and integration with releases.

**Code Optimization:**

* Optimized asset slice allocation in `ReleaseFileSystem.Open` by pre-allocating the slice with the correct capacity to improve performance.