### PR TITLE
Add retries when fetching data

### DIFF
--- a/ghrfs.go
+++ b/ghrfs.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -31,6 +32,11 @@ const (
 	releaseURLMask  = `repos/%s/%s/releases/tags/%s`
 	githubAPIURL    = "api.github.com"
 	releaseDataFile = ".release-data.json"
+
+	// retryInitialWait is the backoff before the first retry; it doubles on
+	// each subsequent attempt up to retryMaxWait.
+	retryInitialWait = 500 * time.Millisecond
+	retryMaxWait     = 30 * time.Second
 )
 
 func New(optFns ...optFunc) (*ReleaseFileSystem, error) {
@@ -55,8 +61,9 @@ func NewWithOptions(opts *Options) (*ReleaseFileSystem, error) {
 	}
 
 	rfs := &ReleaseFileSystem{
-		Options: *opts,
-		client:  c,
+		Options:   *opts,
+		client:    c,
+		retryWait: retryInitialWait,
 	}
 
 	if err := rfs.LoadRelease(); err != nil {
@@ -75,9 +82,10 @@ var (
 
 // ReleaseFileSystem implements fs.FS by reading data a GitHub release.
 type ReleaseFileSystem struct {
-	Options Options
-	Release ReleaseData
-	client  *github.Client
+	Options   Options
+	Release   ReleaseData
+	client    *github.Client
+	retryWait time.Duration
 }
 
 // ReleaseData captures the release information from github
@@ -108,12 +116,7 @@ func (rfs *ReleaseFileSystem) LoadRelease() error {
 	}
 
 	// Call the API to get the data
-	resp, err := rfs.client.Call(
-		context.Background(), "GET", releaseURL, nil,
-	)
-	if resp.StatusCode > 399 || resp.StatusCode < 200 {
-		return fmt.Errorf("HTTP error %d when getting release data", resp.StatusCode)
-	}
+	resp, err := rfs.getWithRetry(context.Background(), rfs.client, releaseURL)
 	if err != nil {
 		return fmt.Errorf("loading release: %w", err)
 	}
@@ -260,6 +263,51 @@ func getClientForURL(urlString, token string) (*github.Client, error) {
 	return c, nil
 }
 
+// getWithRetry issues an authenticated GET, retrying transient failures
+// (network errors and HTTP 429 or 5xx responses) with exponential backoff up
+// to Options.Retries additional attempts. Client errors (4xx other than 429)
+// are returned immediately. On success the response is returned with its body
+// open; the caller is responsible for closing it.
+func (rfs *ReleaseFileSystem) getWithRetry(ctx context.Context, client *github.Client, reqURL string) (*http.Response, error) {
+	wait := rfs.retryWait
+	if wait <= 0 {
+		wait = retryInitialWait
+	}
+
+	for attempt := uint(0); ; attempt++ {
+		resp, err := client.Call(ctx, http.MethodGet, reqURL, nil)
+		if err == nil {
+			return resp, nil
+		}
+
+		// A response carrying a 4xx status (other than 429) is a permanent
+		// client error and must not be retried.
+		if resp != nil {
+			retryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+			resp.Body.Close() //nolint:errcheck,gosec
+			if !retryable {
+				return nil, err
+			}
+		}
+
+		if attempt >= rfs.Options.Retries {
+			return nil, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+		if wait < retryMaxWait {
+			wait *= 2
+			if wait > retryMaxWait {
+				wait = retryMaxWait
+			}
+		}
+	}
+}
+
 // OpenRemoteFile returns the asset file connected to its data stream
 func (rfs *ReleaseFileSystem) OpenRemoteFile(name string) (fs.File, error) {
 	i, ok := rfs.Release.fileIndex[name]
@@ -280,18 +328,11 @@ func (rfs *ReleaseFileSystem) OpenRemoteFile(name string) (fs.File, error) {
 		return nil, err
 	}
 
-	// Send the request to the API
-	resp, err := c.Call(
-		context.Background(), "GET",
-		asset.URL, nil,
-	)
+	// Send the request to fetch the asset. The body is handed to the returned
+	// AssetFile's DataStream and closed by the caller via AssetFile.Close.
+	resp, err := rfs.getWithRetry(context.Background(), c, asset.URL) //nolint:bodyclose
 	if err != nil {
 		return nil, fmt.Errorf("requesting asset %q: %w", name, err)
-	}
-
-	if resp.StatusCode > 399 || resp.StatusCode < 200 {
-		resp.Body.Close() //nolint:errcheck,gosec
-		return nil, fmt.Errorf("HTTP error %d when getting asset %q", resp.StatusCode, name)
 	}
 
 	// Create a NEW AssetFile instance for each Open() call

--- a/options.go
+++ b/options.go
@@ -27,6 +27,10 @@ type Options struct {
 	// releases. When empty, the underlying GitHub client falls back to the
 	// GITHUB_TOKEN environment variable.
 	Token string
+	// Retries is the number of additional attempts (with exponential backoff)
+	// made when a release or asset request fails with a transient error
+	// (a network error, or HTTP 429 or 5xx). Zero disables retries.
+	Retries uint
 }
 
 // Default options
@@ -34,6 +38,7 @@ var defaultOptions = Options{
 	Host:              githubAPIURL,
 	Cache:             false,
 	ParallelDownloads: 3,
+	Retries:           3,
 }
 
 const releasePathPattern = `/([A-Za-z0-9-_\.]+)/([A-Za-z0-9-_\.]+)/releases/tag/(\S+)`
@@ -85,6 +90,16 @@ func WithHost(hostname string) optFunc {
 func WithToken(token string) optFunc {
 	return func(opts *Options) error {
 		opts.Token = token
+		return nil
+	}
+}
+
+// WithRetries sets how many additional attempts are made (with exponential
+// backoff) when fetching release data or an asset fails with a transient error
+// (a network error, or HTTP 429 or 5xx). Zero disables retries.
+func WithRetries(retries uint) optFunc {
+	return func(opts *Options) error {
+		opts.Retries = retries
 		return nil
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package ghrfs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/carabiner-dev/github"
+	"github.com/stretchr/testify/require"
+)
+
+// step is one scripted result returned by scriptedCaller, mimicking the GitHub
+// client's caller: an HTTP error carries a non-nil response and a non-nil error,
+// while a network error carries a nil response.
+type step struct {
+	resp *http.Response
+	err  error
+}
+
+func okStep() step {
+	return step{resp: &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("body"))}}
+}
+
+func httpErrStep(status int) step {
+	return step{
+		resp: &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(""))},
+		err:  fmt.Errorf("HTTP Error %d sending request", status),
+	}
+}
+
+func netErrStep() step {
+	return step{err: errors.New("dial tcp: connection refused")}
+}
+
+type scriptedCaller struct {
+	mu    sync.Mutex
+	steps []step
+	calls int
+}
+
+func (s *scriptedCaller) RequestWithContext(_ context.Context, _, _ string, _ io.Reader) (*http.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.calls >= len(s.steps) {
+		return nil, errors.New("unexpected extra call")
+	}
+	st := s.steps[s.calls]
+	s.calls++
+	return st.resp, st.err
+}
+
+func TestGetWithRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		retries    uint
+		steps      []step
+		wantCalls  int
+		wantErr    bool
+		wantStatus int
+	}{
+		{"success-first-try", 3, []step{okStep()}, 1, false, http.StatusOK},
+		{"retries-5xx-then-succeeds", 3, []step{httpErrStep(http.StatusServiceUnavailable), okStep()}, 2, false, http.StatusOK},
+		{"retries-429-then-succeeds", 3, []step{httpErrStep(http.StatusTooManyRequests), okStep()}, 2, false, http.StatusOK},
+		{"retries-network-error", 3, []step{netErrStep(), okStep()}, 2, false, http.StatusOK},
+		{"no-retry-on-404", 3, []step{httpErrStep(http.StatusNotFound)}, 1, true, 0},
+		{"exhausts-retries", 2, []step{httpErrStep(500), httpErrStep(500), httpErrStep(500)}, 3, true, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &scriptedCaller{steps: tc.steps}
+			client, err := github.NewClient(github.WithCaller(caller))
+			require.NoError(t, err)
+
+			rfs := &ReleaseFileSystem{
+				Options:   Options{Retries: tc.retries},
+				retryWait: time.Millisecond, // keep the test fast
+			}
+			resp, err := rfs.getWithRetry(context.Background(), client, "https://example.com/x")
+
+			require.Equal(t, tc.wantCalls, caller.calls)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, resp)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantStatus, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds robust retry logic for fetching release data and assets, improving resilience to transient network and server errors. It introduces exponential backoff for retries, makes the number of retries configurable, and provides comprehensive tests to ensure correct behavior. The main changes are grouped below.

**Retry Logic and Error Handling Improvements:**

* Introduced a `getWithRetry` method to `ReleaseFileSystem` that retries transient failures (network errors, HTTP 429, and 5xx responses) with exponential backoff up to a configurable number of attempts. Permanent client errors (non-429 4xx) are not retried.
* Updated both `LoadRelease` and `OpenRemoteFile` to use `getWithRetry` for all HTTP GET requests, improving reliability when fetching release data and assets. [[1]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bL111-R119) [[2]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bL283-L296)

**Configuration Enhancements:**

* Added a `Retries` field to the `Options` struct (defaulting to 3) and a `WithRetries` option function, allowing users to configure how many retry attempts are made on transient errors. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R30-R41) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703R97-R106)
* Defined constants for initial and maximum backoff durations (`retryInitialWait`, `retryMaxWait`) to control exponential backoff timing.
* Added a `retryWait` field to `ReleaseFileSystem` to track and adjust the backoff delay. [[1]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bR88) [[2]](diffhunk://#diff-a31cefba083d91c822d4ec673233f009e5231ae40f681b1063071ef13398cc9bR66)

**Testing:**

* Added a new test suite in `retry_test.go` that verifies the retry logic under various scenarios, including network errors, HTTP 429, 5xx, and non-retryable 4xx responses.