### PR TITLE
Update golangci-lint to v2.13

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -33,4 +33,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13

--- a/ghrfs.go
+++ b/ghrfs.go
@@ -371,7 +371,7 @@ func (rfs *ReleaseFileSystem) CacheRelease() error {
 	}
 
 	// Now copy the file data to the local cache
-	t := throttler.New((rfs.Options.ParallelDownloads), len(rfs.Release.Assets))
+	t := throttler.New(rfs.Options.ParallelDownloads, len(rfs.Release.Assets))
 	for _, a := range rfs.Release.Assets {
 		go func() {
 			// Check if the options have preferences for max size or extensions


### PR DESCRIPTION
Bumps the golangci-lint version pinned in the repository's lint workflow(s) from v2.12 to v2.13.

Latest release: https://github.com/golangci/golangci-lint/releases/tag/v2.13.1

Signed-off-by: Biner <biner@carabiner.dev>
